### PR TITLE
Create pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull-request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull-request.md
@@ -1,0 +1,32 @@
+# Description
+
+Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Closes #[REPLACE WITH ISSUE NUMBER]
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# Screenshots
+
+## Desktop
+
+## Tablet
+
+## Mobile
+
+# Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes


### PR DESCRIPTION
Copied over the organization-wide [PR template](https://github.com/ScottyLabs/.github/blob/main/.github/PULL_REQUEST_TEMPLATE/pull-request.md), since it doesn't seem like GitHub supports applying it on an organization level yet.

Replaced the testing section with screenshots for different viewports instead.