### PR TITLE
Remove ghost column on events page

### DIFF
--- a/pages/events.tsx
+++ b/pages/events.tsx
@@ -3,7 +3,7 @@ import Event from "../src/components/Event";
 import Timeline from "../src/components/Timeline";
 import Typography from "../src/components/Typography";
 import BaseLayout from "../src/layouts/BaseLayout";
-import styles from "../styles/Design.module.scss";
+import styles from "../styles/Events.module.scss";
 
 export default function Events() {
   return (

--- a/src/components/Event/index.module.scss
+++ b/src/components/Event/index.module.scss
@@ -43,6 +43,9 @@
   flex-direction: row;
   align-items: center;
   justify-content: flex-end;
+  @include between($breakpoint-md, $breakpoint-lg) {
+    max-width: 50%;
+  }
 }
 
 .eventImage {

--- a/styles/Events.module.scss
+++ b/styles/Events.module.scss
@@ -1,0 +1,61 @@
+@import "./variables.scss";
+@import "./mixins.scss";
+
+.pageContainer {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  justify-content: space-between;
+}
+
+.pageContent {
+  width: 80%;
+  margin: 3em auto 0 auto;
+
+  @include down($breakpoint-lg) {
+    width: 90%;
+  }
+}
+
+.aboutSection {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2em;
+  margin-top: 1em;
+
+  @include down($breakpoint-sm) {
+    grid-template-columns: none;
+    grid-template-rows: 1fr;
+  }
+}
+
+.softwareIconContainer {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  gap: 2em;
+
+  @include down($breakpoint-sm) {
+    gap: 1em;
+    justify-content: space-between;
+  }
+}
+
+.softwareIcon {
+  height: 64px;
+  width: 64px;
+
+  @include down($breakpoint-sm) {
+    height: 48px;
+    width: 48px;
+  }
+
+  @include down($breakpoint-xs) {
+    height: 36px;
+    width: 36px;
+  }
+}
+
+.projectTimeline {
+  margin-top: 5em;
+}


### PR DESCRIPTION
# Description
 A bunch of style fixes for the events page. An artifact from the design page, it still has an empty column on the right for the landing blurb, which takes up space:
 
![image](https://user-images.githubusercontent.com/24856195/186699384-0d4a5313-f1de-415a-93b6-376e4c851e97.png)

This change removes it as well as fixes image sizing for the event images.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Screenshots

## Desktop

## Tablet
![image](https://user-images.githubusercontent.com/24856195/186699624-7f747b3b-719f-419e-a370-c70a2e063bd4.png)

## Mobile

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
