### PR TITLE
Fix missing gradient on safari

### DIFF
--- a/src/components/Gradient/AnimatedGradient.tsx
+++ b/src/components/Gradient/AnimatedGradient.tsx
@@ -1,0 +1,25 @@
+import clsx from "clsx";
+import { useEffect } from "react";
+import { SubGradientProps } from ".";
+import styles from "./index.module.scss";
+
+export default function AnimatedGradient({ className }: SubGradientProps) {
+  useEffect(() => {
+    if (window?.Gradient != null) {
+      const gradient = new window.Gradient();
+      gradient.freqX = 14e-5;
+      gradient.freqY = 29e-5;
+      gradient.freqDelta = 1e-4;
+      gradient.amp = 100;
+      gradient.initGradient("#gradient-canvas");
+    }
+  }, []);
+
+  return (
+    <canvas
+      className={clsx(styles.canvas, className)}
+      id="gradient-canvas"
+      data-transition-in
+    />
+  );
+}

--- a/src/components/Gradient/index.module.scss
+++ b/src/components/Gradient/index.module.scss
@@ -54,7 +54,15 @@
 }
 
 .gradientSafari {
-  height: 80%;
+  height: 75%;
+
+  @include down($breakpoint-lg) {
+    height: 70%;
+  }
+
+  @include down($breakpoint-sm) {
+    height: 75%;
+  }
 }
 
 .gradientPath {

--- a/src/components/Gradient/index.module.scss
+++ b/src/components/Gradient/index.module.scss
@@ -53,6 +53,10 @@
   clip-path: url("#gradientClipPath");
 }
 
+.gradientSafari {
+  height: 80%;
+}
+
 .gradientPath {
   @include down($breakpoint-md) {
     display: none;

--- a/src/components/Gradient/index.tsx
+++ b/src/components/Gradient/index.tsx
@@ -46,7 +46,7 @@ function ExpandedGradient({ className }: SubGradientProps) {
   return (
     <div className={clsx(styles.gradientContainer, className)}>
       <AnimatedGradientNoSSR
-        className={clsx(isSafari() ? styles.safariGradient : styles.gradient)}
+        className={clsx(isSafari() ? styles.gradientSafari : styles.gradient)}
       />
       <svg width={0} height={0}>
         <defs>

--- a/src/components/Gradient/index.tsx
+++ b/src/components/Gradient/index.tsx
@@ -1,5 +1,7 @@
 import clsx from "clsx";
+import dynamic from "next/dynamic";
 import { useEffect } from "react";
+import isSafari from "../../utils/isSafari";
 import styles from "./index.module.scss";
 
 interface GradientProps {
@@ -7,7 +9,7 @@ interface GradientProps {
   expanded?: boolean;
 }
 
-interface SubGradientProps {
+export interface SubGradientProps {
   className?: string;
 }
 
@@ -32,6 +34,10 @@ function AnimatedGradient({ className }: SubGradientProps) {
   );
 }
 
+const AnimatedGradientNoSSR = dynamic(() => import("./AnimatedGradient"), {
+  ssr: false,
+});
+
 /**
  * Expanded gradient with a wave-masked bottom border.
  * Used in the home page with the hero icon
@@ -39,7 +45,9 @@ function AnimatedGradient({ className }: SubGradientProps) {
 function ExpandedGradient({ className }: SubGradientProps) {
   return (
     <div className={clsx(styles.gradientContainer, className)}>
-      <AnimatedGradient className={styles.gradient} />
+      <AnimatedGradientNoSSR
+        className={clsx(isSafari() ? styles.safariGradient : styles.gradient)}
+      />
       <svg width={0} height={0}>
         <defs>
           <clipPath id="gradientClipPath" clipPathUnits="objectBoundingBox">

--- a/src/utils/isSafari.ts
+++ b/src/utils/isSafari.ts
@@ -1,0 +1,12 @@
+/**
+ * Returns true if the browser user agent is Safari
+ */
+export default function isSafari() {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  if (navigator.userAgent.indexOf("Chrome") > -1) {
+    return false;
+  }
+  return navigator.userAgent.indexOf("Safari") > -1;
+}

--- a/src/utils/isSafari.ts
+++ b/src/utils/isSafari.ts
@@ -6,7 +6,7 @@ export default function isSafari() {
     return false;
   }
   if (navigator.userAgent.indexOf("Chrome") > -1) {
-    return true;
+    return false;
   }
   return navigator.userAgent.indexOf("Safari") > -1;
 }

--- a/src/utils/isSafari.ts
+++ b/src/utils/isSafari.ts
@@ -6,7 +6,7 @@ export default function isSafari() {
     return false;
   }
   if (navigator.userAgent.indexOf("Chrome") > -1) {
-    return false;
+    return true;
   }
   return navigator.userAgent.indexOf("Safari") > -1;
 }


### PR DESCRIPTION
# Description

Add conditional svg clip path application based on whether or not the received user agent is safari.

Closes #50 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Screenshots

## Desktop
![image](https://user-images.githubusercontent.com/24856195/189263021-29186590-29fb-49fb-ae48-83b2d05ee76e.png)


## Tablet

## Mobile

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
